### PR TITLE
Hotfix: Fix callgraph construction to support default method implementations.

### DIFF
--- a/src/main/java/soot/jimple/toolkits/callgraph/VirtualCalls.java
+++ b/src/main/java/soot/jimple/toolkits/callgraph/VirtualCalls.java
@@ -82,7 +82,24 @@ public class VirtualCalls {
         && container.getDeclaringClass().getType() != target.getDeclaringClass().getType()
         && !target.getName().equals("<init>") && subSig != sigClinit) {
 
-      return resolveNonSpecial(container.getDeclaringClass().getSuperclass().getType(), subSig, appOnly);
+      /*
+       * BEGIN: Umbrella hotfix/callgraph-default-methods
+       */
+      // return resolveNonSpecial(container.getDeclaringClass().getSuperclass().getType(), subSig, appOnly);
+      SootMethod ret = resolveNonSpecial(container.getDeclaringClass().getSuperclass().getType(), subSig, appOnly);
+      if (ret == null) {
+        for (SootClass i : container.getDeclaringClass().getInterfaces()) {
+    			ret = resolveNonSpecial(i.getType(), subSig, appOnly);
+    			if (ret != null) {
+    				break;
+    			}
+    		}
+      }
+      return ret;
+      /*
+       * END: Umbrella hotfix/callgraph-default-methods
+       */
+      
     } else {
       return target;
     }
@@ -115,6 +132,21 @@ public class VirtualCalls {
       SootClass c = cls.getSuperclassUnsafe();
       if (c != null) {
         ret = resolveNonSpecial(c.getType(), subSig);
+
+      /*
+       * BEGIN: Umbrella hotfix/callgraph-default-methods
+       */
+      if (ret == null) {
+	      for (SootClass i : cls.getInterfaces()) {
+	          ret = resolveNonSpecial(i.getType(), subSig);
+	          if (ret != null) {
+	    		  break;
+	    	  }	
+	      }
+      }
+      /*
+       * END: Umbrella hotfix/callgraph-default-methods
+       */
       }
     }
     vtbl.put(subSig, ret);


### PR DESCRIPTION
This hotfix adds partial support for default method implementations by modifying the callgraph construction code.

Note that this change alone might not yet be completely sufficient, as a similar feature branch exists on [Stable/soot](https://github.com/Sable/soot/commits/feature/default-methods) indicating that a lot of other changes might also be necessary to accomplish this specific task, but that other feature branch is not yet merged into develop.